### PR TITLE
feature: make export flag configurable for StructIO

### DIFF
--- a/revpimodio2/io.py
+++ b/revpimodio2/io.py
@@ -1197,7 +1197,7 @@ class StructIO(IOBase):
                 kwargs.get("defaultvalue", None),
                 bitlength,
                 parentio._slc_address.start,
-                False,
+                kwargs.get('export', parentio.export),
                 str(parentio._slc_address.start).rjust(4, "0"),
                 kwargs.get("bmk", ""),
                 bitaddress

--- a/revpimodio2/modio.py
+++ b/revpimodio2/modio.py
@@ -388,6 +388,16 @@ class RevPiModIO(object):
                         "".format(io, creplaceio[io]["bit"])
                     )
 
+            if "export" in creplaceio[io]:
+                try:
+                    dict_replace["export"] = creplaceio[io].getboolean("export")
+                except Exception:
+                    raise ValueError(
+                        "replace_io_file: could not convert '{0}' "
+                        "export '{1}' to bool"
+                        "".format(io, creplaceio[io]["export"])
+                    )
+
             # Convert defaultvalue from config file
             if "defaultvalue" in creplaceio[io]:
                 if dict_replace["frm"] == "?":
@@ -845,6 +855,8 @@ class RevPiModIO(object):
                     cp[io.name]["defaultvalue"] = str(io.defaultvalue)
                 if io.bmk != "":
                     cp[io.name]["bmk"] = io.bmk
+                if io.export is not None:
+                    cp[io.name]["export"] = io.export
 
         try:
             with open(filename, "w") as fh:

--- a/revpimodio2/modio.py
+++ b/revpimodio2/modio.py
@@ -855,8 +855,8 @@ class RevPiModIO(object):
                     cp[io.name]["defaultvalue"] = str(io.defaultvalue)
                 if io.bmk != "":
                     cp[io.name]["bmk"] = io.bmk
-                if io.export is not None:
-                    cp[io.name]["export"] = io.export
+                if io._export & 2:
+                    cp[io.name]["export"] = str(io._export & 1)
 
         try:
             with open(filename, "w") as fh:


### PR DESCRIPTION
As discussed earlier todayt this PR will allow the configuration of the `export` flag in `StructIO`.

This can either be done via `replace_io()` or in the replace io file. The flag is also written to the file when using the export (only set if `export` distinct from `None`)