### PR TITLE
Scope bit address with byte address

### DIFF
--- a/revpimodio2/io.py
+++ b/revpimodio2/io.py
@@ -176,7 +176,7 @@ class IOList(object):
                 if type(oldio) == StructIO:
                     # Hier gibt es schon einen neuen IO
                     if oldio._bitshift:
-                        if io._bitshift == oldio._bitshift:
+                        if io._bitshift == oldio._bitshift and io._slc_address == oldio._slc_address:
                             raise MemoryError(
                                 "bit {0} already assigned to '{1}'".format(
                                     io._bitaddress, oldio._name


### PR DESCRIPTION
Scope bit address with byte address in order to allow `replace_io` on data types bigger than 8 bit (like `WORD`). With the current implementation it is only possible to replace up to 8 bits (unique bit addresses 0-7) in a replaceable data type, which is fixed with this PR.