### PR TITLE
fix: raise on failed switching cycles ioctl

### DIFF
--- a/src/revpimodio2/io.py
+++ b/src/revpimodio2/io.py
@@ -1288,9 +1288,13 @@ class RelaisOutput(IOBase):
                         self.__ioctl_arg,
                     )
                 except Exception as e:
-                    # If not implemented, we return the max value and set an error
-                    ioctl_return_value = b"\xff" * struct.calcsize(self.__ioctl_arg_format)
+                    # A failed ioctl means the counters could not be read, e.g.
+                    # the module is not present or not responding. Returning a
+                    # fake value would hide that from the caller, so raise.
                     self._parentdevice._modio._gotioerror("rocounter", e)
+                    raise RuntimeError(
+                        "could not read switching cycles from module: {0}".format(e)
+                    ) from e
 
         elif hasattr(self._parentdevice._modio._myfh, "ioctl"):
             # IOCTL over network


### PR DESCRIPTION
A failed ioctl was hidden from the caller by returning the maximum counter value. Applications and tests then processed 4294967295 as a real switching cycle count, for example when the module is not present. Count the io error as before but raise, so the caller can tell a dead module from a worn relay.